### PR TITLE
デフォルト動作では、空フィールドをnullとして読み込むように変更

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.nablarch.framework'
-version = '1.0.1'
+version = '1.1.0'
 description = 'CSV/固定長ファイルとJavaBeanのバインディングを実現する'
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,13 @@ dependencies {
 
   // test api
   testCompile 'org.jmockit:jmockit:1.13'
-  testCompile 'junit:junit:4.10'
-  testCompile 'com.nablarch.dev:nablarch-test-support:0.0.5'
+  testCompile 'junit:junit:4.12'
+  testCompile 'org.hamcrest:hamcrest-all:1.3'
+  testCompile('com.nablarch.dev:nablarch-test-support:0.0.5') {
+    exclude module: 'nablarch-core-applog'
+    exclude module: 'junit'
+    exclude module: 'nablarch-core-jdbc'
+  }
   testRuntime "com.nablarch.framework:nablarch-core-applog:${nablarchCoreApplogVersion}"
   cobertura 'org.slf4j:slf4j-nop:1.7.12' // for cobertura
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 24 10:17:46 JST 2016
+#Mon Jan 16 10:26:00 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip

--- a/src/main/java/nablarch/common/databind/DataBindUtil.java
+++ b/src/main/java/nablarch/common/databind/DataBindUtil.java
@@ -94,8 +94,8 @@ public final class DataBindUtil {
                     .withIgnoreEmptyLine(csvFormat.ignoreEmptyLine())
                     .withRequiredHeader(csvFormat.requiredHeader())
                     .withCharset(csvFormat.charset())
+                    .withEmptyToNull(csvFormat.nullToEmpty())
                     .withQuoteMode(csvFormat.quoteMode());
-
         }
 
         if (config.getQuoteMode() == CsvDataBindConfig.QuoteMode.CUSTOM) {

--- a/src/main/java/nablarch/common/databind/csv/CsvDataBindConfig.java
+++ b/src/main/java/nablarch/common/databind/csv/CsvDataBindConfig.java
@@ -13,22 +13,23 @@ import nablarch.core.util.annotation.Published;
  * CSVのフォーマットを表すクラス。
  * <p/>
  * デフォルト設定を使用する場合は、{@link #DEFAULT}オブジェクトを使用する。<br/>
- * 独自の設定を行う場合は、{@link #CsvDataBindConfig(char, String, char, boolean, boolean, String[], Charset, QuoteMode, List)}
+ * 独自の設定を行う場合は、{@link #CsvDataBindConfig(char, String, char, boolean, boolean, String[], Charset, boolean, QuoteMode, List)}
  * を使用しオブジェクトを生成するか、{@link #DEFAULT}オブジェクトのセッタを実行して値を設定する。
  * <p/>
  * 下記にデフォルトの設定値を示す。
  * <pre>
- * 列区切り文字                -->  ","
- * 行区切り文字                -->  "\r\n"(CRLF)
- * フィールド囲み文字          -->  """
- * 空行を無視するか否か        -->  無視する(true)
- * ヘッダ行が必須か否か        -->  必須(true)
- * ヘッダーに出力するタイトル  -->  空のString型配列
- * 文字コード                  -->  UTF-8
+ * 列区切り文字                          -->  ","
+ * 行区切り文字                          -->  "\r\n"(CRLF)
+ * フィールド囲み文字                    -->  """
+ * 空行を無視するか否か                  -->  無視する(true)
+ * ヘッダ行が必須か否か                  -->  必須(true)
+ * ヘッダーに出力するタイトル            -->  空のString型配列
+ * 文字コード                            -->  UTF-8
+ * 空のフィールドをnullに変換するか否か  --> 変換する(true)
  * フィールド囲み文字で囲む
- * フィールドを指定するモード  -->  NORMAL(フィールド囲み文字、フィールド区切り文字、改行が存在するフィールドが対象となる)
+ * フィールドを指定するモード            -->  NORMAL(フィールド囲み文字、フィールド区切り文字、改行が存在するフィールドが対象となる)
  * フィールド囲み文字で囲む
- * フィールドのリスト          -->  空のリスト
+ * フィールドのリスト                    -->  空のリスト
  * </pre>
  *
  * @author Naoki Yamamoto
@@ -60,6 +61,9 @@ public class CsvDataBindConfig implements DataBindConfig {
     /** 出力時にフィールド囲み文字で囲むフィールドを指定するモード */
     private final QuoteMode quoteMode;
 
+    /** 空のフィールドをnullに変換するかどうか */
+    private final boolean emptyToNull;
+
     /** 出力時にフィールド囲み文字で囲むフィールドのリスト */
     private final List<String> quotedColumnNames;
 
@@ -75,6 +79,7 @@ public class CsvDataBindConfig implements DataBindConfig {
             true,                       // ヘッダー
             new String[0],              // ヘッダーに出力するタイトル
             Charset.forName("UTF-8"),   // 文字コード
+            true,                      // 空のフィールドをnullに変換するかどうか
             QuoteMode.NORMAL,           // 出力時にフィールド囲み文字で囲むフィールドを指定するモード
             Collections.<String>emptyList()  // フィールド囲み文字で囲むフィールドのリスト
     );
@@ -102,6 +107,7 @@ public class CsvDataBindConfig implements DataBindConfig {
      * @param requiredHeader ヘッダ行(タイトル行)が必須か否か
      * @param headerTitles ヘッダーに出力するタイトル
      * @param charset 文字コード
+     * @param emptyToNull 空のフィールドをnullに変換するかどうか
      * @param quoteMode 出力時にフィールド囲み文字で囲むフィールドを指定するモード
      * @param quotedColumnNames フィールド囲み文字で囲むフィールドのリスト
      * @throws IllegalArgumentException 行区切り文字が「\r\n(CRLF)・\r(CR)・\n(LF)」以外の場合
@@ -112,7 +118,9 @@ public class CsvDataBindConfig implements DataBindConfig {
             final char quote,
             final boolean ignoreEmptyLine,
             final boolean requiredHeader,
-            final String[] headerTitles, final Charset charset,
+            final String[] headerTitles,
+            final Charset charset,
+            final boolean emptyToNull,
             final QuoteMode quoteMode,
             final List<String> quotedColumnNames) {
 
@@ -126,6 +134,7 @@ public class CsvDataBindConfig implements DataBindConfig {
         this.ignoreEmptyLine = ignoreEmptyLine;
         this.requiredHeader = requiredHeader;
         this.charset = charset;
+        this.emptyToNull = emptyToNull;
         this.headerTitles = headerTitles;
         this.quoteMode = quoteMode;
         this.quotedColumnNames = quotedColumnNames;
@@ -155,6 +164,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 headerTitles,
                 charset,
+                emptyToNull,
                 quoteMode,
                 quotedColumnNames);
     }
@@ -185,6 +195,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 headerTitles,
                 charset,
+                emptyToNull,
                 quoteMode,
                 quotedColumnNames);
     }
@@ -213,6 +224,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 headerTitles,
                 charset,
+                emptyToNull,
                 quoteMode,
                 quotedColumnNames);
     }
@@ -250,6 +262,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 headerTitles,
                 charset,
+                emptyToNull,
                 quoteMode,
                 quotedColumnNames);
     }
@@ -287,6 +300,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 newOption,
                 headerTitles,
                 charset,
+                emptyToNull,
                 quoteMode,
                 quotedColumnNames);
     }
@@ -315,6 +329,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 newHeaderTitles,
                 charset,
+                emptyToNull,
                 quoteMode,
                 quotedColumnNames);
     }
@@ -353,6 +368,36 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 headerTitles,
                 newCharset,
+                emptyToNull,
+                quoteMode,
+                quotedColumnNames);
+    }
+
+    /**
+     * 空フィールドをnullに置き換えるか否か。
+     *
+     * @return 置き換える場合は{@code true}
+     */
+    public boolean isEmptyToNull() {
+        return emptyToNull;
+    }
+
+    /**
+     * 空フィールドをnullに置き換えるか否かを設定する。
+     *
+     * @param newEmptyToNull nullに置き換える場合は{@code true}
+     * @return 新しい{@link CsvDataBindConfig}
+     */
+    public CsvDataBindConfig withEmptyToNull(final boolean newEmptyToNull) {
+        return new CsvDataBindConfig(
+                fieldSeparator,
+                lineSeparator,
+                quote,
+                ignoreEmptyLine,
+                requiredHeader,
+                headerTitles,
+                charset,
+                newEmptyToNull,
                 quoteMode,
                 quotedColumnNames);
     }
@@ -381,6 +426,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 headerTitles,
                 charset,
+                emptyToNull,
                 newQuoteMode,
                 quotedColumnNames);
     }
@@ -412,6 +458,7 @@ public class CsvDataBindConfig implements DataBindConfig {
                 requiredHeader,
                 headerTitles,
                 charset,
+                emptyToNull,
                 quoteMode,
                 Arrays.asList(fieldNames));
     }

--- a/src/main/java/nablarch/common/databind/csv/CsvFormat.java
+++ b/src/main/java/nablarch/common/databind/csv/CsvFormat.java
@@ -43,6 +43,9 @@ public @interface CsvFormat {
     /** 文字コード */
     String charset();
 
+    /** 空フィールドをnullに置き換えるかどうか */
+    boolean nullToEmpty();
+
     /**
      * 出力時に{@link #quote}で囲むフィールド。
      * <p/>

--- a/src/main/java/nablarch/common/databind/csv/CsvTokenizer.java
+++ b/src/main/java/nablarch/common/databind/csv/CsvTokenizer.java
@@ -59,9 +59,9 @@ class CsvTokenizer {
         final int c = reader.read();
         if (isEndOfFile(c) || isEndOfLine(c)) {
             hasNext = false;
-            return "";
+            return format.isEmptyToNull() ? null : "";
         } else if (isFieldSeparator(c)) {
-            return "";
+            return format.isEmptyToNull() ? null : "";
         } else if (isQuote(c)) {
             return readQuotedItem();
         } else {

--- a/src/test/java/nablarch/common/databind/DataBindUtilTest.java
+++ b/src/test/java/nablarch/common/databind/DataBindUtilTest.java
@@ -87,7 +87,9 @@ public class DataBindUtilTest {
 
         // クォートモードがNORMAL
         CsvDataBindConfig actual = (CsvDataBindConfig) DataBindUtil.createDataBindConfig(PersonCustomNormal.class);
-        CsvDataBindConfig expected = new CsvDataBindConfig('\t',"\n",'\'',false, false, new String[]{}, Charset.forName("MS932"), CsvDataBindConfig.QuoteMode.NORMAL, Collections.<String>emptyList());
+        CsvDataBindConfig expected = new CsvDataBindConfig('\t',"\n",'\'',false, false, new String[]{}, Charset.forName("MS932"),
+                false, CsvDataBindConfig.QuoteMode.NORMAL, Collections.<String>emptyList()
+        );
         assertThat(actual.getFieldSeparator(), is(expected.getFieldSeparator()));
         assertThat(actual.getLineSeparator(), is(expected.getLineSeparator()));
         assertThat(actual.getQuote(), is(expected.getQuote()));
@@ -99,7 +101,9 @@ public class DataBindUtilTest {
 
         // クォートモードがALL
         actual = (CsvDataBindConfig) DataBindUtil.createDataBindConfig(PersonCustomAll.class);
-        expected = new CsvDataBindConfig('\t',"\n",'\'',false,false, new String[]{}, Charset.forName("MS932"), CsvDataBindConfig.QuoteMode.ALL, Collections.<String>emptyList());
+        expected = new CsvDataBindConfig('\t',"\n",'\'',false,false, new String[]{}, Charset.forName("MS932"), false,
+                CsvDataBindConfig.QuoteMode.ALL, Collections.<String>emptyList()
+        );
         assertThat(actual.getFieldSeparator(), is(expected.getFieldSeparator()));
         assertThat(actual.getLineSeparator(), is(expected.getLineSeparator()));
         assertThat(actual.getQuote(), is(expected.getQuote()));
@@ -111,7 +115,9 @@ public class DataBindUtilTest {
 
         // クォートモードがNOT_NUMERIC
         actual = (CsvDataBindConfig) DataBindUtil.createDataBindConfig(PersonCustomNotNumeric.class);
-        expected = new CsvDataBindConfig('\t',"\n",'\'',false,false, new String[]{}, Charset.forName("MS932"), CsvDataBindConfig.QuoteMode.NOT_NUMERIC, Collections.<String>emptyList());
+        expected = new CsvDataBindConfig('\t',"\n",'\'',false,false, new String[]{}, Charset.forName("MS932"), false,
+                CsvDataBindConfig.QuoteMode.NOT_NUMERIC, Collections.<String>emptyList()
+        );
         assertThat(actual.getFieldSeparator(), is(expected.getFieldSeparator()));
         assertThat(actual.getLineSeparator(), is(expected.getLineSeparator()));
         assertThat(actual.getQuote(), is(expected.getQuote()));
@@ -123,7 +129,9 @@ public class DataBindUtilTest {
 
         // クォートモードがCUSTOM
         actual = (CsvDataBindConfig) DataBindUtil.createDataBindConfig(PersonCustom.class);
-        expected = new CsvDataBindConfig('\t',"\n",'\'',false,false, new String[]{}, Charset.forName("MS932"), CsvDataBindConfig.QuoteMode.CUSTOM, Collections.<String>emptyList());
+        expected = new CsvDataBindConfig('\t',"\n",'\'',false,false, new String[]{}, Charset.forName("MS932"), false,
+                CsvDataBindConfig.QuoteMode.CUSTOM, Collections.<String>emptyList()
+        );
         assertThat(actual.getFieldSeparator(), is(expected.getFieldSeparator()));
         assertThat(actual.getLineSeparator(), is(expected.getLineSeparator()));
         assertThat(actual.getQuote(), is(expected.getQuote()));
@@ -384,7 +392,15 @@ public class DataBindUtilTest {
     }
 
     @Csv(type = Csv.CsvType.CUSTOM, properties = {"age", "name"})
-    @CsvFormat(fieldSeparator = '\t', lineSeparator = "\n", quote = '\'', ignoreEmptyLine = false, requiredHeader = false, charset = "MS932", quoteMode = CsvDataBindConfig.QuoteMode.NORMAL)
+    @CsvFormat(fieldSeparator = '\t',
+            lineSeparator = "\n",
+            quote = '\'',
+            ignoreEmptyLine = false,
+            requiredHeader = false,
+            charset = "MS932",
+            nullToEmpty = false,
+            quoteMode = CsvDataBindConfig.QuoteMode.NORMAL
+    )
     public static class PersonCustomNormal {
         private Integer age;
         private String name;
@@ -407,7 +423,14 @@ public class DataBindUtilTest {
     }
 
     @Csv(type = Csv.CsvType.CUSTOM, properties = {"age", "name"})
-    @CsvFormat(fieldSeparator = '\t', lineSeparator = "\n", quote = '\'', ignoreEmptyLine = false, requiredHeader = false, charset = "MS932", quoteMode = CsvDataBindConfig.QuoteMode.ALL)
+    @CsvFormat(fieldSeparator = '\t',
+            lineSeparator = "\n",
+            quote = '\'',
+            ignoreEmptyLine = false,
+            requiredHeader = false,
+            charset = "MS932",
+            nullToEmpty = false,
+            quoteMode = CsvDataBindConfig.QuoteMode.ALL)
     public static class PersonCustomAll {
         private Integer age;
         private String name;
@@ -430,7 +453,14 @@ public class DataBindUtilTest {
     }
 
     @Csv(type = Csv.CsvType.CUSTOM, properties = {"age", "name"})
-    @CsvFormat(fieldSeparator = '\t', lineSeparator = "\n", quote = '\'', ignoreEmptyLine = false, requiredHeader = false, charset = "MS932", quoteMode = CsvDataBindConfig.QuoteMode.NOT_NUMERIC)
+    @CsvFormat(fieldSeparator = '\t',
+            lineSeparator = "\n",
+            quote = '\'',
+            ignoreEmptyLine = false,
+            requiredHeader = false,
+            charset = "MS932",
+            nullToEmpty = false,
+            quoteMode = CsvDataBindConfig.QuoteMode.NOT_NUMERIC)
     public static class PersonCustomNotNumeric {
         private Integer age;
         private String name;
@@ -453,7 +483,14 @@ public class DataBindUtilTest {
     }
 
     @Csv(type = Csv.CsvType.CUSTOM, properties = {"age", "name"})
-    @CsvFormat(fieldSeparator = '\t', lineSeparator = "\n", quote = '\'', ignoreEmptyLine = false, requiredHeader = false, charset = "MS932", quoteMode = CsvDataBindConfig.QuoteMode.CUSTOM)
+    @CsvFormat(fieldSeparator = '\t',
+            lineSeparator = "\n",
+            quote = '\'',
+            ignoreEmptyLine = false,
+            requiredHeader = false,
+            charset = "MS932",
+            nullToEmpty = false,
+            quoteMode = CsvDataBindConfig.QuoteMode.CUSTOM)
     public static class PersonCustom {
         private Integer age;
         private String name;
@@ -477,7 +514,14 @@ public class DataBindUtilTest {
     }
 
     @Csv(type = Csv.CsvType.DEFAULT, properties = {"age", "name"})
-    @CsvFormat(fieldSeparator = '\t', lineSeparator = "\n", quote = '\'', ignoreEmptyLine = false, requiredHeader = false, charset = "MS932", quoteMode = CsvDataBindConfig.QuoteMode.NORMAL)
+    @CsvFormat(fieldSeparator = '\t',
+            lineSeparator = "\n",
+            quote = '\'',
+            ignoreEmptyLine = false,
+            requiredHeader = false,
+            charset = "MS932",
+            nullToEmpty = false,
+            quoteMode = CsvDataBindConfig.QuoteMode.NORMAL)
     public static class PersonBoth {
         private Integer age;
         private String name;
@@ -500,7 +544,14 @@ public class DataBindUtilTest {
     }
 
     @Csv(type = Csv.CsvType.CUSTOM, properties = {"age", "name"})
-    @CsvFormat(fieldSeparator = '\t', lineSeparator = "\n", quote = '\'', ignoreEmptyLine = false, requiredHeader = true, charset = "MS932", quoteMode = CsvDataBindConfig.QuoteMode.NORMAL)
+    @CsvFormat(fieldSeparator = '\t',
+            lineSeparator = "\n",
+            quote = '\'',
+            ignoreEmptyLine = false,
+            requiredHeader = true,
+            charset = "MS932",
+            nullToEmpty = false,
+            quoteMode = CsvDataBindConfig.QuoteMode.NORMAL)
     public static class PersonHeader {
         private Integer age;
         private String name;

--- a/src/test/java/nablarch/common/databind/csv/BeanCsvMapperTest.java
+++ b/src/test/java/nablarch/common/databind/csv/BeanCsvMapperTest.java
@@ -314,7 +314,8 @@ public class BeanCsvMapperTest {
             lineSeparator = "\r\n",
             quote = '\'',
             quoteMode = QuoteMode.NOT_NUMERIC,
-            requiredHeader = true
+            requiredHeader = true,
+            nullToEmpty = false
     )
     public static class TsvWithHeaderPerson extends Person {
 

--- a/src/test/java/nablarch/common/databind/csv/CsvDataBindConfigTest.java
+++ b/src/test/java/nablarch/common/databind/csv/CsvDataBindConfigTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertThat;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
+import sun.nio.cs.FastCharsetProvider;
+
 import nablarch.common.databind.csv.CsvDataBindConfig.QuoteMode;
 
 import org.junit.Test;
@@ -17,7 +19,8 @@ public class CsvDataBindConfigTest {
 
     @Test
     public void withQuote() throws Exception {
-        CsvDataBindConfig sut = CsvDataBindConfig.DEFAULT;
+        CsvDataBindConfig sut = CsvDataBindConfig.DEFAULT
+                .withEmptyToNull(false);
 
         sut = sut.withQuote('a');
         assertThat(sut.getQuote(), is('a'));
@@ -29,6 +32,7 @@ public class CsvDataBindConfigTest {
         assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
         assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
         assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
+        assertThat(sut.isEmptyToNull(), is(false));
     }
 
     @Test
@@ -46,11 +50,12 @@ public class CsvDataBindConfigTest {
         assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
         assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
         assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
+        assertThat(sut.isEmptyToNull(), is(CsvDataBindConfig.DEFAULT.isEmptyToNull()));
     }
 
     @Test
     public void withLineSeparator() throws Exception {
-        CsvDataBindConfig sut = CsvDataBindConfig.DEFAULT;
+        CsvDataBindConfig sut = CsvDataBindConfig.DEFAULT.withEmptyToNull(false);
 
         sut = sut.withLineSeparator("\r");
         assertThat(sut.getLineSeparator(), is("\r"));
@@ -68,6 +73,7 @@ public class CsvDataBindConfigTest {
         assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
         assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
         assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
+        assertThat(sut.isEmptyToNull(), is(false));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -96,6 +102,25 @@ public class CsvDataBindConfigTest {
     }
 
     @Test
+    public void withEmptyToNull() throws Exception {
+        CsvDataBindConfig sut = CsvDataBindConfig.DEFAULT;
+
+        sut = sut.withEmptyToNull(true);
+        assertThat(sut.isEmptyToNull(), is(true));
+        sut = sut.withEmptyToNull(false);
+        assertThat(sut.isEmptyToNull(), is(false));
+
+        assertThat(sut.getFieldSeparator(), is(CsvDataBindConfig.DEFAULT.getFieldSeparator()));
+        assertThat(sut.getQuote(), is(CsvDataBindConfig.DEFAULT.getQuote()));
+        assertThat(sut.getLineSeparator(), is(CsvDataBindConfig.DEFAULT.getLineSeparator()));
+        assertThat(sut.getHeaderTitles(), is(CsvDataBindConfig.DEFAULT.getHeaderTitles()));
+        assertThat(sut.getQuotedColumnNames(), is(CsvDataBindConfig.DEFAULT.getQuotedColumnNames()));
+        assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
+        assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
+        assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
+    }
+
+    @Test
     public void withHeaderTitles() throws Exception {
         CsvDataBindConfig sut = CsvDataBindConfig.DEFAULT;
 
@@ -110,7 +135,7 @@ public class CsvDataBindConfigTest {
         assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
         assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
         assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
-
+        assertThat(sut.isEmptyToNull(), is(CsvDataBindConfig.DEFAULT.isEmptyToNull()));
     }
 
     @Test
@@ -129,6 +154,7 @@ public class CsvDataBindConfigTest {
         assertThat(sut.getQuotedColumnNames(), is(CsvDataBindConfig.DEFAULT.getQuotedColumnNames()));
         assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
         assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
+        assertThat(sut.isEmptyToNull(), is(CsvDataBindConfig.DEFAULT.isEmptyToNull()));
     }
 
     @Test
@@ -147,6 +173,7 @@ public class CsvDataBindConfigTest {
         assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
         assertThat(sut.getQuotedColumnNames(), is(CsvDataBindConfig.DEFAULT.getQuotedColumnNames()));
         assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
+        assertThat(sut.isEmptyToNull(), is(CsvDataBindConfig.DEFAULT.isEmptyToNull()));
     }
 
     @Test
@@ -163,6 +190,7 @@ public class CsvDataBindConfigTest {
         assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
         assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
         assertThat(sut.isIgnoreEmptyLine(), is(CsvDataBindConfig.DEFAULT.isIgnoreEmptyLine()));
+        assertThat(sut.isEmptyToNull(), is(CsvDataBindConfig.DEFAULT.isEmptyToNull()));
     }
 
     @Test
@@ -183,5 +211,6 @@ public class CsvDataBindConfigTest {
         assertThat(sut.isRequiredHeader(), is(CsvDataBindConfig.DEFAULT.isRequiredHeader()));
         assertThat(sut.getQuoteMode(), is(CsvDataBindConfig.DEFAULT.getQuoteMode()));
         assertThat(sut.getQuotedColumnNames(), is(CsvDataBindConfig.DEFAULT.getQuotedColumnNames()));
+        assertThat(sut.isEmptyToNull(), is(CsvDataBindConfig.DEFAULT.isEmptyToNull()));
     }
 }

--- a/src/test/java/nablarch/common/databind/csv/CsvDataReaderLineTest.java
+++ b/src/test/java/nablarch/common/databind/csv/CsvDataReaderLineTest.java
@@ -33,7 +33,7 @@ public class CsvDataReaderLineTest {
                 new Param[] {new Param("空の場合", "", (String[]) null)},
                 new Param[] {new Param("1カラムの場合", "1カラム",  new String[] {"1カラム"})},
                 new Param[] {new Param("2カラムの場合", "1カラム,2カラム",  new String[] {"1カラム", "2カラム"})},
-                new Param[] {new Param("空要素がある場合", ",,", new String[] {"", "", ""})},
+                new Param[] {new Param("空要素がある場合", ",,", new String[] {null, null, null})},
                 new Param[] {new Param("クォートで囲まれている場合", "\"囲まれている\"",  new String[] {"囲まれている"})},
                 new Param[] {new Param("ダブルクォート内でダブルクォートがエスケープされている", "\"エスケープ有り→\"\"←これエスケープ\"",  new String[] {"エスケープ有り→\"←これエスケープ"})},
                 new Param[] {new Param("ダブルクォート内にCRが存在している", "\"CR→\r←CR\"",  new String[] {"CR→\r←CR"})},

--- a/src/test/java/nablarch/common/databind/csv/CsvDataReaderTest.java
+++ b/src/test/java/nablarch/common/databind/csv/CsvDataReaderTest.java
@@ -53,7 +53,7 @@ public class CsvDataReaderTest {
     @Test
     public void testLineSeparator() throws Exception {
         resource.writeLine("1,2,3");
-        resource.writeLine("10,20,30");
+        resource.writeLine("10,,30");
         resource.close();
 
         final DataReader<String[]> sut = new CsvDataReader(resource.createReader(), format);
@@ -66,7 +66,7 @@ public class CsvDataReaderTest {
         final String[] line2 = sut.read();
         assertThat("要素数は3", line2.length, is(3));
         assertThat(line2[0], is("10"));
-        assertThat(line2[1], is("20"));
+        assertThat(line2[1], is(nullValue()));
         assertThat(line2[2], is("30"));
 
         final String[] line3 = sut.read();
@@ -88,9 +88,9 @@ public class CsvDataReaderTest {
 
         final DataReader<String[]> sut = new CsvDataReader(resource.createReader(), format);
         assertThat("要素数は3", sut.read(), is(new String[] {"1", "2", "3"}));
-        assertThat("空行なので要素数は1", sut.read(), is(new String[] {""}));
+        assertThat("空行なので要素数は1", sut.read(), is(new String[] {null}));
         assertThat("要素数は3", sut.read(), is(new String[] {"10", "20", "30"}));
-        assertThat("空行なので要素数は1", sut.read(), is(new String[] {""}));
+        assertThat("空行なので要素数は1", sut.read(), is(new String[] {null}));
         assertThat("ファイルの終わりに到達したのでnull", sut.read(), is(nullValue()));
     }
 

--- a/src/test/java/nablarch/common/databind/csv/CsvDataReaderTsvFormatTest.java
+++ b/src/test/java/nablarch/common/databind/csv/CsvDataReaderTsvFormatTest.java
@@ -65,9 +65,9 @@ public class CsvDataReaderTsvFormatTest {
 
         final CsvDataReader sut = new CsvDataReader(resource.createReader(), CsvDataBindConfig.TSV);
         assertThat("要素数は3", sut.read(), is(new String[] {"1", "2", "3"}));
-        assertThat("空行なので要素数は1", sut.read(), is(new String[] {""}));
+        assertThat("空行なので要素数は1", sut.read(), is(new String[] {null}));
         assertThat("要素数は3", sut.read(), is(new String[] {"10", "20", "30"}));
-        assertThat("空行なので要素数は1", sut.read(), is(new String[] {""}));
+        assertThat("空行なので要素数は1", sut.read(), is(new String[] {null}));
         assertThat("ファイルの終わりに到達したのでnull", sut.read(), is(nullValue()));
     }
 

--- a/src/test/java/nablarch/common/databind/csv/CsvTokenizerTest.java
+++ b/src/test/java/nablarch/common/databind/csv/CsvTokenizerTest.java
@@ -1,5 +1,6 @@
 package nablarch.common.databind.csv;
 
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -8,6 +9,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.CharBuffer;
+
+import org.hamcrest.CoreMatchers;
 
 import org.junit.Test;
 
@@ -33,7 +36,7 @@ public class CsvTokenizerTest {
         assertThat("1番目の要素:1", sut.next(), is("1"));
         assertThat("2番目の要素:2", sut.next(), is("2"));
         assertThat("3番目の要素:3", sut.next(), is("3"));
-        assertThat("おわり", sut.next(), is(""));
+        assertThat("おわり", sut.next(), is(nullValue()));
     }
 
     /**


### PR DESCRIPTION
デフォルト動作では、空フィールドをnullとして読み込むように変更

今までの動作に変更したい場合は、明示的にempty -> nullを行わないように設定する必要がある。

NAB-20 未入力値の扱いに関するテストを見直す