### PR TITLE
nablarch-parentで定義したJUnitのバージョンアップに伴い、Kotlinの型推論が機能しなくなった箇所があったため修正。

### DIFF
--- a/src/test/java/nablarch/common/databind/fixedlength/BeanFixedLengthMapperTest.kt
+++ b/src/test/java/nablarch/common/databind/fixedlength/BeanFixedLengthMapperTest.kt
@@ -4,6 +4,7 @@ import nablarch.common.databind.ObjectMapperFactory
 import nablarch.common.databind.fixedlength.converter.Lpad
 import nablarch.common.databind.fixedlength.converter.Rpad
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.isA
 import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -208,7 +209,7 @@ class BeanFixedLengthMapperTest {
 
             expectedException.expect(IllegalArgumentException::class.java)
             expectedException.expectMessage("record length is invalid. expected_length:19, actual_length:20")
-            expectedException.expectCause(Matchers.instanceOf(BufferOverflowException::class.java))
+            expectedException.expectCause(isA(BufferOverflowException::class.java))
             sut.write(TestBean("testname", "testtext", 1000))
 
         }

--- a/src/test/java/nablarch/common/databind/fixedlength/FixedLengthBeanMapperTest.kt
+++ b/src/test/java/nablarch/common/databind/fixedlength/FixedLengthBeanMapperTest.kt
@@ -294,7 +294,7 @@ class FixedLengthBeanMapperTest {
             }
         }).use { 
             expectedException.expect(RuntimeException::class.java)
-            expectedException.expectCause(instanceOf(IOException::class.java))
+            expectedException.expectCause(isA(IOException::class.java))
             it.read()
         }
     }

--- a/src/test/java/nablarch/common/databind/fixedlength/MapFixedLengthMapperTest.kt
+++ b/src/test/java/nablarch/common/databind/fixedlength/MapFixedLengthMapperTest.kt
@@ -4,6 +4,7 @@ import nablarch.common.databind.ObjectMapperFactory
 import nablarch.common.databind.fixedlength.converter.Lpad
 import nablarch.common.databind.fixedlength.converter.Rpad
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.isA
 import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -157,7 +158,7 @@ class MapFixedLengthMapperTest {
             assertThat(sut, Matchers.instanceOf(MapFixedLengthMapper::class.java))
 
             expectedException.expect(IllegalArgumentException::class.java)
-            expectedException.expectCause(Matchers.instanceOf(ClassCastException::class.java))
+            expectedException.expectCause(isA(ClassCastException::class.java))
             expectedException.expectMessage("record data must be java.util.Map type.")
             sut.write(mapOf("recordName" to RecordType.HEADER, "header" to "invalid"))
         }
@@ -184,7 +185,7 @@ class MapFixedLengthMapperTest {
 
             expectedException.expect(IllegalArgumentException::class.java)
             expectedException.expectMessage("record length is invalid. expected_length:19, actual_length:20")
-            expectedException.expectCause(Matchers.instanceOf(BufferOverflowException::class.java))
+            expectedException.expectCause(isA(BufferOverflowException::class.java))
             sut.write(mapOf("name" to "testname", "text" to "testtext", "age" to 1000))
 
         }


### PR DESCRIPTION
* https://github.com/nablarch/nablarch-parent/pull/13 に伴う修正。件名通りの修正を行った。
* 本PRはリリース不要。テストコードのみの修正であるため。