### PR TITLE
feat: Java 17 対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,21 +23,6 @@
   <properties>
     <kotlin.version>1.7.22</kotlin.version>
   </properties>
-
-  <profiles>
-    <profile>
-      <id>java6</id>
-      <properties>
-        <kotlin.version>1.4.32</kotlin.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>java7</id>
-      <properties>
-        <kotlin.version>1.4.32</kotlin.version>
-      </properties>
-    </profile>
-  </profiles>
   
   <dependencies>
     <dependency>

--- a/src/test/java/nablarch/common/databind/fixedlength/FixedLengthBeanMapperTest.kt
+++ b/src/test/java/nablarch/common/databind/fixedlength/FixedLengthBeanMapperTest.kt
@@ -9,7 +9,6 @@ import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
-import sun.nio.cs.ext.MS932
 import java.io.*
 import java.nio.charset.*
 

--- a/src/test/java/nablarch/common/databind/fixedlength/converter/BinaryConverterTest.kt
+++ b/src/test/java/nablarch/common/databind/fixedlength/converter/BinaryConverterTest.kt
@@ -7,7 +7,6 @@ import org.junit.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
-import sun.nio.cs.ext.MS932
 
 /**
  * [nablarch.common.databind.fixedlength.converter.Binary.BinaryConverter]のテスト


### PR DESCRIPTION
`sun.nio.cs.ext.MS932` は内部APIなので 17 でカプセル化が強化された影響でコンパイルエラーになるようになっていました。
そもそもimportはしてるけど全く使っていないので、importを消しました。