### PR TITLE
MultiLayoutを公開APIとして追加

### DIFF
--- a/src/main/java/nablarch/common/databind/fixedlength/MultiLayout.java
+++ b/src/main/java/nablarch/common/databind/fixedlength/MultiLayout.java
@@ -1,12 +1,14 @@
 package nablarch.common.databind.fixedlength;
 
 import nablarch.common.databind.fixedlength.MultiLayoutConfig.RecordIdentifier;
+import nablarch.core.util.annotation.Published;
 
 /**
  * マルチレイアウトな固定長データを表すクラス。
  *
  * @author Naoki Yamamoto
  */
+@Published
 public abstract class MultiLayout {
 
     /** レコード名 */


### PR DESCRIPTION
[解説書内](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/data_io/data_bind.html?_ijt=4o6q7i5lus16e0mqidikdkijtn&_ij_reload=RELOAD_ON_SAVE#data-bind-fixed-length-format-multi-layout)で継承が案内されていたが、MultiLayoutクラス自体は公開APIとなっていなかったため修正しました。